### PR TITLE
Add neural net tic tac toe self-play example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "boardgamer"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
-burn = "0.11"
+burn = { version = "0.17.1", features = ["wgpu"] }
+rand = "0.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,66 @@
-use burn::tensor::{backend::ndarray::NdArrayBackend, Tensor};
+mod tic_tac_toe;
+use tic_tac_toe::*;
+
+fn play_game(p1: &mut NeuralPlayer, p2: &mut NeuralPlayer) -> i32 {
+    let mut board = Board::new();
+    let mut states_p1 = Vec::new();
+    let mut actions_p1 = Vec::new();
+    let mut states_p2 = Vec::new();
+    let mut actions_p2 = Vec::new();
+
+    loop {
+        // Player 1 turn
+        let action = p1.select_action(&board, 1);
+        board.make_move(action);
+        states_p1.push(board_to_state(&board, 1));
+        actions_p1.push(action);
+        match board.check_winner() {
+            GameResult::Win(w) => {
+                if w == 1 { p1.train(&states_p1, &actions_p1, 1.0); p2.train(&states_p2, &actions_p2, -1.0); return 1; }
+                else { p1.train(&states_p1, &actions_p1, -1.0); p2.train(&states_p2, &actions_p2, 1.0); return -1; }
+            },
+            GameResult::Draw => {
+                p1.train(&states_p1, &actions_p1, 0.0);
+                p2.train(&states_p2, &actions_p2, 0.0);
+                return 0;
+            },
+            GameResult::Ongoing => {}
+        }
+
+        // Player 2 turn
+        let action = p2.select_action(&board, -1);
+        board.make_move(action);
+        states_p2.push(board_to_state(&board, -1));
+        actions_p2.push(action);
+        match board.check_winner() {
+            GameResult::Win(w) => {
+                if w == 1 { p1.train(&states_p1, &actions_p1, 1.0); p2.train(&states_p2, &actions_p2, -1.0); return 1; }
+                else { p1.train(&states_p1, &actions_p1, -1.0); p2.train(&states_p2, &actions_p2, 1.0); return -1; }
+            },
+            GameResult::Draw => {
+                p1.train(&states_p1, &actions_p1, 0.0);
+                p2.train(&states_p2, &actions_p2, 0.0);
+                return 0;
+            },
+            GameResult::Ongoing => {}
+        }
+    }
+}
 
 fn main() {
-    type Backend = NdArrayBackend<f32>;
+    let mut player1 = NeuralPlayer::new(0, 0.01);
+    let mut player2 = NeuralPlayer::new(1, 0.01);
 
-    // Create a simple tensor using the Burn machine learning crate
-    let tensor = Tensor::<Backend, 1>::from_data([1.0, 2.0, 3.0]);
-    println!("{:?}", tensor);
+    let mut stats = [0i32; 3]; // [p1 wins, p2 wins, draws]
+
+    for _ in 0..1000 {
+        match play_game(&mut player1, &mut player2) {
+            1 => stats[0] += 1,
+            -1 => stats[1] += 1,
+            0 => stats[2] += 1,
+            _ => {}
+        }
+    }
+
+    println!("P1 wins: {} P2 wins: {} Draws: {}", stats[0], stats[1], stats[2]);
 }

--- a/src/tic_tac_toe.rs
+++ b/src/tic_tac_toe.rs
@@ -1,0 +1,138 @@
+pub const BOARD_SIZE: usize = 9;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum GameResult {
+    Win(i32),
+    Draw,
+    Ongoing,
+}
+
+#[derive(Clone)]
+pub struct Board {
+    pub cells: [i32; BOARD_SIZE],
+    pub player: i32,
+}
+
+impl Board {
+    pub fn new() -> Self {
+        Self { cells: [0; BOARD_SIZE], player: 1 }
+    }
+
+    pub fn is_valid_move(&self, idx: usize) -> bool {
+        idx < BOARD_SIZE && self.cells[idx] == 0
+    }
+
+    pub fn make_move(&mut self, idx: usize) -> bool {
+        if self.is_valid_move(idx) {
+            self.cells[idx] = self.player;
+            self.player *= -1;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn check_winner(&self) -> GameResult {
+        const WIN_LINES: [[usize; 3]; 8] = [
+            [0, 1, 2],
+            [3, 4, 5],
+            [6, 7, 8],
+            [0, 3, 6],
+            [1, 4, 7],
+            [2, 5, 8],
+            [0, 4, 8],
+            [2, 4, 6],
+        ];
+
+        for line in WIN_LINES.iter() {
+            let sum = self.cells[line[0]] + self.cells[line[1]] + self.cells[line[2]];
+            if sum == 3 {
+                return GameResult::Win(1);
+            } else if sum == -3 {
+                return GameResult::Win(-1);
+            }
+        }
+
+        if self.cells.iter().all(|&c| c != 0) {
+            GameResult::Draw
+        } else {
+            GameResult::Ongoing
+        }
+    }
+}
+
+pub fn board_to_state(board: &Board, perspective: i32) -> [f32; BOARD_SIZE] {
+    let mut state = [0f32; BOARD_SIZE];
+    for i in 0..BOARD_SIZE {
+        state[i] = board.cells[i] as f32 * perspective as f32;
+    }
+    state
+}
+
+use rand::{rngs::StdRng, Rng, SeedableRng};
+
+#[derive(Clone)]
+pub struct NeuralPlayer {
+    pub weights: [[f32; BOARD_SIZE]; BOARD_SIZE],
+    pub lr: f32,
+    pub rng: StdRng,
+}
+
+impl NeuralPlayer {
+    pub fn new(seed: u64, lr: f32) -> Self {
+        Self { weights: [[0.0; BOARD_SIZE]; BOARD_SIZE], lr, rng: StdRng::seed_from_u64(seed) }
+    }
+
+    pub fn select_action(&mut self, board: &Board, perspective: i32) -> usize {
+        let state = board_to_state(board, perspective);
+        let logits = self.forward(&state);
+        let probs = softmax(&logits);
+        sample_from_probs(&mut self.rng, &probs)
+    }
+
+    fn forward(&self, state: &[f32; BOARD_SIZE]) -> [f32; BOARD_SIZE] {
+        let mut out = [0f32; BOARD_SIZE];
+        for i in 0..BOARD_SIZE {
+            for j in 0..BOARD_SIZE {
+                out[i] += self.weights[i][j] * state[j];
+            }
+        }
+        out
+    }
+
+    pub fn train(&mut self, states: &[[f32; BOARD_SIZE]], actions: &[usize], reward: f32) {
+        for (state, &action) in states.iter().zip(actions.iter()) {
+            let logits = self.forward(state);
+            let probs = softmax(&logits);
+            for i in 0..BOARD_SIZE {
+                let grad = (if i == action { 1.0 } else { 0.0 }) - probs[i];
+                for j in 0..BOARD_SIZE {
+                    self.weights[i][j] += self.lr * reward * grad * state[j];
+                }
+            }
+        }
+    }
+}
+
+fn softmax(logits: &[f32; BOARD_SIZE]) -> [f32; BOARD_SIZE] {
+    let max = logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    let mut exp: [f32; BOARD_SIZE] = [0.0; BOARD_SIZE];
+    let mut sum = 0.0;
+    for i in 0..BOARD_SIZE {
+        exp[i] = (logits[i] - max).exp();
+        sum += exp[i];
+    }
+    for i in 0..BOARD_SIZE {
+        exp[i] /= sum;
+    }
+    exp
+}
+
+fn sample_from_probs(rng: &mut StdRng, probs: &[f32; BOARD_SIZE]) -> usize {
+    let mut r = rng.gen::<f32>();
+    for i in 0..BOARD_SIZE {
+        if r < probs[i] { return i; }
+        r -= probs[i];
+    }
+    BOARD_SIZE - 1
+}


### PR DESCRIPTION
## Summary
- add a simple reinforcement learning example that pits two neural networks
  against each other in tic-tac-toe
- add `rand` dependency and downgrade edition for stable Rust
- upgrade burn to 0.17.1 with the `wgpu` feature

## Testing
- `cargo check` *(fails to complete in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68431a4c4bc88330a5d6f6b74084e442