### PR TITLE
Fix RL state recording bug

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,14 @@ fn play_game(p1: &mut NeuralPlayer, p2: &mut NeuralPlayer) -> i32 {
 
     loop {
         // Player 1 turn
+        // Capture the board state before making a move so the network learns
+        // which action to take given the current situation. Previously the
+        // state was recorded after the move, causing the network to learn to
+        // repeat moves on already occupied cells.
+        let state = board_to_state(&board, 1);
         let action = p1.select_action(&board, 1);
         board.make_move(action);
-        states_p1.push(board_to_state(&board, 1));
+        states_p1.push(state);
         actions_p1.push(action);
         match board.check_winner() {
             GameResult::Win(w) => {
@@ -35,9 +40,10 @@ fn play_game(p1: &mut NeuralPlayer, p2: &mut NeuralPlayer) -> i32 {
         }
 
         // Player 2 turn
+        let state = board_to_state(&board, -1);
         let action = p2.select_action(&board, -1);
         board.make_move(action);
-        states_p2.push(board_to_state(&board, -1));
+        states_p2.push(state);
         actions_p2.push(action);
         match board.check_winner() {
             GameResult::Win(w) => {

--- a/src/tic_tac_toe.rs
+++ b/src/tic_tac_toe.rs
@@ -254,3 +254,45 @@ fn sample_from_probs(rng: &mut StdRng, probs: &[f32; BOARD_SIZE]) -> usize {
     }
     BOARD_SIZE - 1
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_make_move_and_player_switch() {
+        let mut board = Board::new();
+        assert!(board.make_move(0));
+        // player should switch from 1 to -1
+        assert_eq!(board.player, -1);
+        // cell updated
+        assert_eq!(board.cells[0], 1);
+        // cannot move to same cell again
+        assert!(!board.make_move(0));
+    }
+
+    #[test]
+    fn test_board_to_state_perspective() {
+        let mut board = Board::new();
+        board.make_move(0); // player 1 moves
+        board.make_move(1); // player -1 moves
+        let state_p1 = board_to_state(&board, 1);
+        let state_p2 = board_to_state(&board, -1);
+        // board cells: [1, -1, 0, ...]
+        assert_eq!(state_p1[0], 1.0);
+        assert_eq!(state_p1[1], -1.0);
+        assert_eq!(state_p2[0], -1.0); // from opponent perspective
+        assert_eq!(state_p2[1], 1.0);
+    }
+
+    #[test]
+    fn test_select_action_returns_valid_move() {
+        let mut player = NeuralPlayer::new(0, 0.0);
+        let mut board = Board::new();
+        board.make_move(0); // occupy cell 0
+        for _ in 0..10 {
+            let action = player.select_action(&board, 1);
+            assert!(board.is_valid_move(action));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- record board state before selecting moves in `play_game`

This ensures the neural network trains on the state that led to each action rather than the state after the move, preventing learning invalid actions.

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68435f300d008330a9308c28fdb65616